### PR TITLE
Add vercel based subdomain redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,64 @@
+{
+  "redirects": [
+     {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.aegisub.org"
+        }
+      ],
+      "destination": "https://aegisub.org/docs/:path*"
+    },
+    {
+      "source": "/:path*/",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.aegisub.org"
+        }
+      ],
+      "destination": "https://aegisub.org/docs/:path*/"
+    },
+	{
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "blog.aegisub.org"
+        }
+      ],
+      "destination": "https://aegisub.org/blog/:path*"
+    },
+    {
+      "source": "/:path*/",
+      "has": [
+        {
+          "type": "host",
+          "value": "blog.aegisub.org"
+        }
+      ],
+      "destination": "https://aegisub.org/blog/:path*/"
+    },
+	{
+      "source": "(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "ftp.aegisub.org"
+        }
+      ],
+      "destination": "https://aegisub.org/downloads/"
+    },
+	{
+      "source": "(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "devel.aegisub.org"
+        }
+      ],
+      "destination": "https://github.com/Aegisub/Aegisub"
+    }
+  ]
+}


### PR DESCRIPTION
Configures vercel redirects like this:
| Old  | New |
| ------------- | ------------- |
| `docs.aegisub.org/*` | `aegisub.org/docs/*` |
| `blog.aegisub.org/*` | `aegisub.org/blog/*` |
| `ftp.aegisub.org` | `aegisub.org/downloads/` |
| `devel.aegisub.org` | `github.com/Aegisub/Aegisub` |

The duplicate entries for docs and blog seem to be necessary due to vercel otherwise not matching trailing slashes.

Behavior can be tested on `aegisub.info`