### PR TITLE
fix TOC in ASS_Tags.md

### DIFF
--- a/content/en/docs/latest/ASS_Tags.md
+++ b/content/en/docs/latest/ASS_Tags.md
@@ -18,7 +18,7 @@ using some basic tags.
 The following tags are written in the middle of the text, and not inside
 override blocks (i.e. not between { and }).
 
-{{<tag-def-box title="Soft line break" id="\n">}}\\n{{</tag-def-box>}}
+{{%tag-def-box title="Soft line break"%}}\\n{{%/tag-def-box%}}
 Insert a forced line break, but only when in wrapping mode 2. (See
 [the \\q tag]({{< relref "ASS_Tags#\q" >}})). Note that this is a lowercase n.
 
@@ -26,11 +26,11 @@ In all other wrapping modes, this is replaced by a regular space. This is
 rarely (if ever) actually useful. If you're not sure whether you want this or
 \\N, you probably want \\N.
 
-{{<tag-def-box title="Hard line break" id="\N">}}\\N{{</tag-def-box>}}
+{{%tag-def-box title="Hard line break"%}}\\N{{%/tag-def-box%}}
 Insert a forced line break, regardless of wrapping mode. Note that this is an
 uppercase N.
 
-{{<tag-def-box title="Hard space" id="\h">}}\\h{{</tag-def-box>}}
+{{%tag-def-box title="Hard space"%}}\\h{{%/tag-def-box%}}
 Insert a non-breaking "hard" space. The line will never break automatically
 right before or after a hard space, and hard spaces are not folded when they
 appear at the start or end of a displayed line.
@@ -68,18 +68,18 @@ brackets are not part of the value you should enter. Use the examples as a
 guide to how the tags should be entered. In general, the same rules apply to
 all tags in how they look.
 
-{{<tag-def-box title="Italics" id="\i">}}
+{{%tag-def-box title="Italics"%}}
 \\i1
 \\i0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch _italics_ text on or off. Use `\i1` to enable italics for the following
 text and `\i0` to disable italics again.
 
-{{<tag-def-box title="Bold" id="\b">}}
+{{%tag-def-box title="Bold"%}}
 \\b1
 \\b0
 \\b<i>\<weight></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch **boldface** text on or off. Use `\b1` to enable boldface for the
 following text and `\b0` to disable boldface again.
 
@@ -108,21 +108,21 @@ do not have more than one or two different weights and you will only be able
 to see "not bold" and "bold" in that case.
 {{</example-box>}}
 
-{{<tag-def-box title="Underline" id="\u">}}
+{{%tag-def-box title="Underline"%}}
 \\u1
 \\u0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch <u>underlined</u> text on or off. Use `\u1` to enable underlining for
 the following text and `\u0` to disable underlining again.
 
-{{<tag-def-box title="Strikeout" id="\s">}}
+{{%tag-def-box title="Strikeout"%}}
 \\s1
 \\s0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch <s>striked out</s> text on or off. Use `\s1` to enable strikeout for
 the following text and `\s0` to disable strikeout again.
 
-{{<tag-def-box title="Border size" id="\bord">}}\\bord<i>\<size></i>{{</tag-def-box>}}
+{{%tag-def-box title="Border size"%}}\\bord<i>\<size></i>{{%/tag-def-box%}}
 Change the width of the border around the text. Set the size to 0 (zero) to
 disable the border entirely.
 
@@ -151,10 +151,10 @@ Disable border entirely.
 Set the border width to 3.7 pixels
 {{</example-box>}}
 
-{{<tag-def-box title="Border size (extended)" id="\xbord">}}
+{{%tag-def-box title="Border size (extended)"%}}
 \\xbord<i>\<size></i>
 \\ybord<i>\<size></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Use the `\xbord` `\ybord` tags to set the border size in X and Y direction
 separately. This can be useful for correcting the border size for anamorphic
 rendering of subtitles.
@@ -165,16 +165,16 @@ override both of them.
 You can set the border width to 0 (zero) in one of the directions to entirely
 disable border in that direction.
 
-{{<tag-def-box title="Shadow distance" id="\shad">}}\\shad<i>\<depth></i>{{</tag-def-box>}}
+{{%tag-def-box title="Shadow distance"%}}\\shad<i>\<depth></i>{{%/tag-def-box%}}
 Set the distance from the text to position the shadow. Set the depth to 0
 (zero) to disable shadow entirely. Works similar to [\\bord]({{< relref "ASS_Tags#\bord" >}}).
 
 The shadow distance can not be negative with this tag.
 
-{{<tag-def-box title="Shadow distance (extended)" id="\xshad">}}
+{{%tag-def-box title="Shadow distance (extended)"%}}
 \\xshad<i>\<depth></i>
 \\yshad<i>\<depth></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Set the distance from the text to position the shadow at, with X and Y
 position set separately. Shadow is only disabled if both X and Y distance is
 0\.
@@ -182,11 +182,11 @@ position set separately. Shadow is only disabled if both X and Y distance is
 Note that unlike \\shad, you can set the distance negative with these tags to
 position the shadow to the top or left of the text.
 
-{{<tag-def-box title="Blur edges" id="\be">}}
+{{%tag-def-box title="Blur edges"%}}
 \\be0
 \\be1
 \\be<i>\<strength></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Enable or disable a subtle softening-effect for the edges of the text. The
 effect isn't always very visible, but it can in some cases make the text look
 better. It is usually more visible at smaller text sizes.
@@ -201,7 +201,7 @@ regular effect. Note that at high values the effect de-generates into
 nothingness, and generally isn't very useful. For strong blurs, `\blur` is
 generally more useful as a result. The _strength_ must be an integer number.
 
-{{<tag-def-box title="Blur edges (Gaussian kernel)" id="\blur">}}\\blur<i>\<strength></i>{{</tag-def-box>}}
+{{%tag-def-box title="Blur edges (Gaussian kernel)"%}}\\blur<i>\<strength></i>{{%/tag-def-box%}}
 In general, this has the same function as the [`\be`]({{< relref "ASS_Tags#\be" >}}) tag, but
 uses a more advanced algorithm that looks better at high strengths. Unlike
 `\be`, the _strength_ can be non-integer here. Set _strength_ to 0 (zero) to
@@ -213,7 +213,7 @@ means that if the text has a border (set with [`\bord`]({{< relref "ASS_Tags#\bo
 border will be blurred, but if there is no border, the main text will be
 blurred instead.
 
-{{<tag-def-box title="Font name" id="\fn">}}\\fn<i>\<name></i>{{</tag-def-box>}}
+{{%tag-def-box title="Font name"%}}\\fn<i>\<name></i>{{%/tag-def-box%}}
 Set the font face to use for the following text. There should be no space
 between `\fn` and the font name, and you should not put parentheses or similar
 around the font name either.
@@ -235,7 +235,7 @@ The text following this tag will be in Arial font.
 The text following this tag will be in Times New Roman font.
 {{</example-box>}}
 
-{{<tag-def-box title="Font size" id="\fs">}}\\fs<i>\<size></i>{{</tag-def-box>}}
+{{%tag-def-box title="Font size"%}}\\fs<i>\<size></i>{{%/tag-def-box%}}
 Set the size of the font. The size specified is the height in script pixels,
 so at font size 40 one line of text is 40 pixels tall. (Technical note: it's
 really typographic (desktop publishing) points, not script pixels, but since
@@ -253,10 +253,10 @@ You can only specify integer font sizes.
 The following text will use a size 10 font.
 {{</example-box>}}
 
-{{<tag-def-box title="Font scale" id="\fscx">}}
+{{%tag-def-box title="Font scale"%}}
 \\fscx<i>\<scale></i>
 \\fscy<i>\<scale></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Adjust the size of the text in X (`\fscx` or Y (`\fscy`) direction. The
 _scale_ given is in percent, so 100 means "original size".
 
@@ -298,19 +298,19 @@ Make the text half height.
 Make the text double size.
 {{</example-box>}}
 
-{{<tag-def-box title="Letter spacing" id="\fsp">}}\\fsp<i>\<spacing></i>{{</tag-def-box>}}
+{{%tag-def-box title="Letter spacing"%}}\\fsp<i>\<spacing></i>{{%/tag-def-box%}}
 Changes the spacing between the individual letters in the text. You can use
 this to spread the text more out visually. The _spacing_ is given in script
 resolution pixels.
 
 Spacing can be negative and can have decimals.
 
-{{<tag-def-box title="Text rotation" id="\frx">}}
+{{%tag-def-box title="Text rotation"%}}
 \\frx<i>\<amount></i>
 \\fry<i>\<amount></i>
 \\frz<i>\<amount></i>
 \\fr<i>\<amount></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Rotates the text along the X, Y or Z axis. The `\fr` tag is a shortcut for `\frz`.
 
 - The **X axis** runs horizontally on the screen. Rotating on it (with
@@ -385,10 +385,10 @@ The following screenshots illustrate the effect of rotating on the different axe
 ![Fr_sample03](/img/3.2/Fr_sample03.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="Text shearing" id="\fax">}}
+{{%tag-def-box title="Text shearing"%}}
 \\fax<i>\<factor></i>
 \\fay<i>\<factor></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Perform a shearing (perspective distortion) transformation of the text. A
 _factor_ of 0 (zero) means no distortion.
 
@@ -402,18 +402,18 @@ coordinate system used for shearing is not affected by the [rotation origin]({{<
 ![shearing](/img/3.2/shearing.png)
 {{</example-box>}}
 
-{{<tag-def-box title="Font encoding" id="\fe">}}\\fe<i>\<id></i>{{</tag-def-box>}}
+{{%tag-def-box title="Font encoding"%}}\\fe<i>\<id></i>{{%/tag-def-box%}}
 Overrides the `Encoding` value of the style.
 This is rarely ever useful or a good idea and should thus be avoided.
 See the [style docs]({{< relref "Styles#the-style-editor" >}}) for more details.
 
-{{<tag-def-box title="Set color" id="\c">}}
+{{%tag-def-box title="Set color"%}}
 \\c&H<i>\<bb>\<gg>\<rr></i>&
 \\1c&H<i>\<bb>\<gg>\<rr></i>&
 \\2c&H<i>\<bb>\<gg>\<rr></i>&
 \\3c&H<i>\<bb>\<gg>\<rr></i>&
 \\4c&H<i>\<bb>\<gg>\<rr></i>&
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Set the color of the following text. The `\c` tag is an abbreviation of `\1c`.
 
 - `\1c` sets the primary fill color.
@@ -430,13 +430,13 @@ must always start with `&H` and end with `&`.
 The Pick Color toolbar buttons ![pick-color-toolbar-buttons](/img/3.2/pick-color-toolbar-buttons.png) can
 assist in picking colors and entering the color codes.
 
-{{<tag-def-box title="Set alpha" id="\alpha">}}
+{{%tag-def-box title="Set alpha"%}}
 \\alpha&H<i>\<aa></i>
 \\1a&H<i>\<aa></i>
 \\2a&H<i>\<aa></i>
 \\3a&H<i>\<aa></i>
 \\4a&H<i>\<aa></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Set the alpha (transparency) of the text.
 
 - `\alpha` sets the alpha of all components at once.
@@ -468,7 +468,7 @@ Set the primary fill alpha to hexadecimal FF, decimal 255, making it invisible
 and effectively leaving only the border and shadow.
 {{</example-box>}}
 
-{{<tag-def-box title="Line alignment" id="\an">}}\\an<i>\<pos></i>{{</tag-def-box>}}
+{{%tag-def-box title="Line alignment"%}}\\an<i>\<pos></i>{{%/tag-def-box%}}
 Specify the alignment of the line. The alignment specifies the position of the
 line when no [position override]({{< relref "ASS_Tags#\pos" >}}) or
 [movement]({{< relref "ASS_Tags#\move" >}}) is in effect, and otherwise specifies the
@@ -488,7 +488,7 @@ keyboard:
 1. Top center
 1. Top right
 
-{{<tag-def-box title="Line alignment (legacy)" id="\a">}}\\a<i>\<pos></i>{{</tag-def-box>}}
+{{%tag-def-box title="Line alignment (legacy)"%}}\\a<i>\<pos></i>{{%/tag-def-box%}}
 Specify the alignment of the line using legacy alignment codes from SubStation
 Alpha. This tag is supported but considered deprecated; you should usually use
 `\an` in new scripts instead, as it is more intuitive.
@@ -510,13 +510,13 @@ top-titles, add 4 to the number, to get mid-titles add 8 to the number:
 - 10: Middle center
 - 11: Middle right
 
-{{<tag-def-box title="Karaoke effect" id="\k">}}
+{{%tag-def-box title="Karaoke effect"%}}
 \\k<i>\<duration></i>
 \\K<i>\<duration></i>
 \\kf<i>\<duration></i>
 \\ko<i>\<duration></i>
 \\kt<i>\<time></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 
 > _Please note that these tags alone only create some very specific effects
 > and all other effects are created with a combination of multiple different
@@ -550,7 +550,7 @@ Additionally the `\kt` tag sets the start time of the next karaoke syllable
 relative to the event’s start. Without `\kt` each syllable start is implicitly
 determined as the sum of all preceding syllable’s duration.
 
-{{<tag-def-box title="Wrap style" id="\q">}}\\q<i>\<style></i>{{</tag-def-box>}}
+{{%tag-def-box title="Wrap style"%}}\\q<i>\<style></i>{{%/tag-def-box%}}
 Determine how line breaking is applied to the subtitle line. The following
 _style_ values are available:
 
@@ -562,7 +562,7 @@ _style_ values are available:
   Both `\n` and `\N` force line breaks.
 - 3: Smart wrapping, similar to style 0, but bottom lines are made wider.
 
-{{<tag-def-box title="Reset style" id="\r">}}\\r<br>\\r<i>\<style></i>{{</tag-def-box>}}
+{{%tag-def-box title="Reset style"%}}\\r<br>\\r<i>\<style></i>{{%/tag-def-box%}}
 Reset the style. This cancels all style overrides in effect, including
 [animations]({{< relref "ASS_Tags#\t" >}}), for all following text.
 
@@ -582,7 +582,7 @@ on the third line the style is reset to "Default" for the "Who are you?"
 text.
 {{</example-box>}}
 
-{{<tag-def-box title="Set position" id="\pos">}}\\pos(<i>\<X></i>,<i>\<Y></i>){{</tag-def-box>}}
+{{%tag-def-box title="Set position"%}}\\pos(<i>\<X></i>,<i>\<Y></i>){{%/tag-def-box%}}
 Set the position of the line. The _X_ and _Y_ coordinates must be integers and
 are given in the script resolution coordinate system. The meaning of _X_ and
 _Y_ changes slightly depending on [alignment]({{< relref "ASS_Tags#\an" >}}).
@@ -602,10 +602,10 @@ The green cross marks the point (320,240) on the video.
 ![Pos_sample03](/img/3.2/Pos_sample03.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="Movement" id="\move">}}
+{{%tag-def-box title="Movement"%}}
 \\move(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>)
 \\move(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>,<i>\<t1</i>>,<i>\<t2</i>>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 The `\move` tag works similar to [`\pos`]({{< relref "ASS_Tags#\pos" >}}) in that it
 positions the subtitle line, the difference is that `\move` makes the subtitle
 move.
@@ -671,7 +671,7 @@ arrive at the point a second and a half (1500 milliseconds) after the line
 first appeared on screen.
 {{</example-box>}}
 
-{{<tag-def-box title="Rotation origin" id="\org">}}\\org(<i>\<X></i>,<i>\<Y></i>){{</tag-def-box>}}
+{{%tag-def-box title="Rotation origin"%}}\\org(<i>\<X></i>,<i>\<Y></i>){{%/tag-def-box%}}
 Set the origin point used for [rotation]({{< relref "ASS_Tags#\frx" >}}). This
 affects all rotations of the line. The _X_ and _Y_ coordinates are given in
 integer script resolution pixels.
@@ -715,7 +715,7 @@ Placing the rotation origin at a far away point allows you to use slight
 without seeming to rotate.
 {{</example-box>}}
 
-{{<tag-def-box title="Fade" id="\fad">}}\\fad(<i>\<fadein></i>,<i>\<fadeout></i>){{</tag-def-box>}}
+{{%tag-def-box title="Fade"%}}\\fad(<i>\<fadein></i>,<i>\<fadeout></i>){{%/tag-def-box%}}
 Produce a fade-in and fade-out effect. The _fadein_ and _fadeout_ times are
 given in milliseconds, ie. 1000 means one second. You can specify _fadein_ or
 _fadeout_ as 0 (zero) to not have any fade effect on that end.
@@ -736,7 +736,7 @@ Fade in the line in the first 1.2 seconds it is to be displayed, and fade it
 out for the last one quarter second it is displayed.
 {{</example-box>}}
 
-{{<tag-def-box title="Fade (complex)" id="\fade">}}\\fade(<i>\<a1</i>>,<i>\<a2</i>>,<i>\<a3</i>>,<i>\<t1</i>>,<i>\<t2</i>>,<i>\<t3</i>>,<i>\<t4</i>>){{</tag-def-box>}}
+{{%tag-def-box title="Fade (complex)"%}}\\fade(<i>\<a1</i>>,<i>\<a2</i>>,<i>\<a3</i>>,<i>\<t1</i>>,<i>\<t2</i>>,<i>\<t3</i>>,<i>\<t4</i>>){{%/tag-def-box%}}
 Perform a five-part fade using three alpha values _a1_, _a2_ and _a3_ and four
 times _t1_, _t2_, _t3_ and _t4_.
 
@@ -762,12 +762,12 @@ invisible. First fade starts when the line starts and lasts 500 milliseconds.
 Second fade starts 1500 milliseconds later, and lasts 200 milliseconds.
 {{</example-box>}}
 
-{{<tag-def-box title="Animated transform" id="\t">}}
+{{%tag-def-box title="Animated transform"%}}
 \\t(<i>\<style modifiers></i>)
 \\t(<i>\<accel></i>,<i>\<style modifiers></i>)
 \\t(<i>\<t1</i>>,<i>\<t2</i>>,<i>\<style modifiers></i>)
 \\t(<i>\<t1</i>>,<i>\<t2</i>>,<i>\<accel></i>,<i>\<style modifiers></i>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 
 Perform a gradual, animated transformation from one style to another. The
 _style modifiers_ are other override tags as specified in this reference. Only
@@ -845,10 +845,10 @@ Same as above, but it will start fast and slow down, still doing the 10 rotation
 Text starts at zero size, i.e. invisible, then grows to 100% size in both X and Y direction.
 {{</example-box>}}
 
-{{<tag-def-box title="Clip (rectangle)" id="\clip">}}
+{{%tag-def-box title="Clip (rectangle)"%}}
 \\clip(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>)
 \\iclip(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Define a rectangle to clip the line, only the part of the line that is inside
 the rectangle is visible. The `\iclip` tag has the opposite effect, it defines
 a rectangle where the line is not shown.
@@ -883,12 +883,12 @@ Example of `\clip(0,0,704,245)` on a 704x480 video:
 ![Clip_sample01](/img/3.2/Clip_sample01.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="Clip (vector drawing)" id="">}}
+{{%tag-def-box title="Clip (vector drawing)" id=""%}}
 \\clip(<i>\<drawing commands></i>)
 \\clip(<i>\<scale></i>,<i>\<drawing commands></i>)
 \\iclip(<i>\<drawing commands></i>)
 \\iclip(<i>\<scale></i>,<i>\<drawing commands></i>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Use the shape defined by a vector drawing to selectively display (`\clip`) or
 hide (`\iclip`) parts of the line.
 

--- a/content/es-us/docs/latest/ASS_Tags.md
+++ b/content/es-us/docs/latest/ASS_Tags.md
@@ -12,16 +12,16 @@ La siguiente es una lista de todas las etiquetas admitidas por el formato Advanc
 
 Las siguientes etiquetas están escritas en el medio del texto y no dentro de bloques de anulación (es decir, no entre { y }).
 
-{{<tag-def-box title="Salto de línea suave" id="\n">}}\\n{{</tag-def-box>}}
+{{%tag-def-box title="Salto de línea suave"%}}\\n{{%/tag-def-box%}}
 Inserta un salto de línea forzado, pero solo cuando esté en el modo de salto 2. (Ver
 [la etiqueta \\q]({{<relref path="ASS_Tags#\q" >}})). Fíjese que es una n minúscula.
 
 En todos los demás modos de salto, esto se reemplaza por un espacio normal. Rara vez (o nunca) es realmente útil. Si no está seguro de si quiere esto o \\N, probablemente quiere \\N.
 
-{{<tag-def-box title="Salto de línea duro" id="\N">}}\\N{{</tag-def-box>}}
+{{%tag-def-box title="Salto de línea duro"%}}\\N{{%/tag-def-box%}}
 Inserta un salto de línea forzado, independientemente del modo de ajuste. Fíjese que es una N mayúscula.
 
-{{<tag-def-box title="Espacio duro" id="\h">}}\\h{{</tag-def-box>}}
+{{%tag-def-box title="Espacio duro"%}}\\h{{%/tag-def-box%}}
 Inserta un espacio "duro" que no se rompa. La línea nunca se dividirá automáticamente justo antes ni después de un espacio duro, y los espacios no se colapsan cuando aparecen al principio o al final de una línea dibujada.
 
 ## Etiquetas manuales
@@ -39,17 +39,17 @@ Algunas etiquetas son "complejas" y aceptan más de un parámetro. En estos caso
 **Nota sobre tipografía:**
 En esta página, todo lo escrito en _cursiva_ rodeado por `<` corchetes angulares `>` es un parámetro y uno tiene que ingresar un valor en su lugar. Los corchetes angulares no forman parte del valor que debe ingresar. Utilice los ejemplos como guía sobre cómo se deben escribir las etiquetas. En general, se aplican las mismas reglas a todas las etiquetas en cuanto a su apariencia.
 
-{{<tag-def-box title="Cursiva" id="\i">}}
+{{%tag-def-box title="Cursiva"%}}
 \\i1
 \\i0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Activa o desactiva el texto en _cursiva_. Utilice `\i1` para habilitar la cursiva para el siguiente texto y `\i0` para deshabilitarla nuevamente.
 
-{{<tag-def-box title="Negrita" id="\b">}}
+{{%tag-def-box title="Negrita"%}}
 \\b1
 \\b0
 \\b<i>\<peso></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Activa o desactiva el texto en **negrita**. Utilice `\b1` para habilitar la negrita para el siguiente texto y `\b0` para desactivarla nuevamente.
 
 La versión <code>\\b<i>\<peso></i></code> permite especificar un peso explícito para usar. Tenga en cuenta que la mayoría de las fuentes sólo admiten uno o dos pesos, por lo que rara vez necesitará utilizarlo. Los pesos de las fuentes son múltiplos de 100, de modo que 100 es el más bajo, 400 es "normal", 700 es "negrita" y 900 es el más pesado.
@@ -72,19 +72,19 @@ La palabra "no" está escrita en negrita.
 Las palabras se escriben con cada vez mayor peso. Tenga en cuenta que la mayoría de las fuentes no tienen más de uno o dos pesos diferentes y en ese caso solo podrá ver "sin negrita" y "negrita".
 {{</example-box>}}
 
-{{<tag-def-box title="Subrayado" id="\u">}}
+{{%tag-def-box title="Subrayado"%}}
 \\u1
 \\u0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Activa o desactiva el texto <u>subrayado</u>. Utilice `\u1` para habilitar el subrayado en el siguiente texto y `\u0` para desactivarlo nuevamente.
 
-{{<tag-def-box title="Tachado" id="\s">}}
+{{%tag-def-box title="Tachado"%}}
 \\s1
 \\s0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Activa o desactiva el texto <s>tachado</s>. Utilice `\s1` para habilitar el tachado del siguiente texto y `\s0` para desactivarlo nuevamente.
 
-{{<tag-def-box title="Grosor de borde" id="\bord">}}\\bord<i>\<grosor></i>{{</tag-def-box>}}
+{{%tag-def-box title="Grosor de borde"%}}\\bord<i>\<grosor></i>{{%/tag-def-box%}}
 Cambia el grosor del borde alrededor del texto. Fije el grosor en 0 (cero) para desactivar el borde por completo.
 
 Si "escalar borde y sombra" (consulte [propiedades del guion]({{<relref path="Properties">}})) está habilitado, el valor se proporciona en píxeles de resolución del guion; de lo contrario, se proporciona en píxeles de resolución de vídeo (lo cual significa que el grosor del borde variará según la resolución del vídeo en la que se renderizan los subtítulos).
@@ -108,47 +108,47 @@ Deshabilitar el borde por completo.
 Establecer el grosor del borde en 3.7 píxeles.
 {{</example-box>}}
 
-{{<tag-def-box title="Grosor de borde (extendido)" id="\xbord">}}
+{{%tag-def-box title="Grosor de borde (extendido)"%}}
 \\xbord<i>\<grosor></i>
 \\ybord<i>\<grosor></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Utilice las etiquetas `\xbord` `\ybord` para establecer el grosor del borde en las direcciones X y Y por separado. Esto puede ser útil para corregir el tamaño del borde en caso del renderizado anamórfico de subtítulos.
 
 Tenga en cuenta que si usa `\bord` después de `\xbord` o `\ybord` en una línea, las anulará a ambas.
 
 Uno puede establecer el grosor del borde en 0 (cero) en una de las direcciones para desactivar completamente el borde en esa dirección.
 
-{{<tag-def-box title="Distancia de sombra" id="\shad">}}\\shad<i>\<profundidad></i>{{</tag-def-box>}}
+{{%tag-def-box title="Distancia de sombra"%}}\\shad<i>\<profundidad></i>{{%/tag-def-box%}}
 Establece la distancia desde el texto para posicionar la sombra. Fijar la profundidad en 0
 (cero) desactiva la sombra por completo. Funciona de manera similar a [\\bord]({{<relref path="ASS_Tags#\bord">}}).
 
 La profundidad de la sombra no puede ser negativa con esta etiqueta.
 
-{{<tag-def-box title="Distancia de sombra (extendida)" id="\xshad">}}
+{{%tag-def-box title="Distancia de sombra (extendida)"%}}
 \\xshad<i>\<profundidad></i>
 \\yshad<i>\<profundidad></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Establece la distancia desde el texto para posicionar la sombra, con las posiciones X y Y configuradas por separado. La sombra solo se desactiva si la distancia X y Y es 0.
 
 Tenga en cuenta que, a diferencia de \\shad, puede establecer la distancia negativa con estas etiquetas para colocar la sombra arriba o izquierda del texto.
 
-{{<tag-def-box title="Bordes borrosos" id="\be">}}
+{{%tag-def-box title="Bordes borrosos"%}}
 \\be0
 \\be1
 \\be<i>\<fuerza></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Habilita o deshabilita un efecto de suavizado sutil para los bordes del texto. El efecto no siempre es muy visible, pero en algunos casos puede hacer que el texto se vea mejor. Suele ser más visible en tamaños de texto más pequeños.
 
 Fíjese que esta etiqueta difumina solo los _bordes_ del texto, no todo. Esto significa que si el texto tiene un borde (establecido con [\\bord]({{<relref path="ASS_Tags#\bord">}})) el borde se verá borroso, pero si no hay borde, el texto principal aparecerá borroso.
 
 En la versión extendida, _fuerza_ es la cantidad de veces que se aplica el efecto normal. Tenga en cuenta que en valores altos el efecto degenera hasta la nada y, en general, no es muy útil. Como resultado, para desenfoques fuertes, `\blur` generalmente es más útil. La _fuerza_ tiene que ser un número entero.
 
-{{<tag-def-box title="Bordes borrosos (núcleo gaussiano)" id="\blur">}}\\blur<i>\<fuerza></i>{{</tag-def-box >}}
+{{%tag-def-box title="Bordes borrosos (núcleo gaussiano)"%}}\\blur<i>\<fuerza></i>{{</tag-def-box >}}
 En general, tiene la misma función que la etiqueta [`\be`]({{<relref path="ASS_Tags#\be">}}), pero utiliza un algoritmo más avanzado que se ve mejor en niveles altos de fuerza. A diferencia de `\be`, la _fuerza_ aquí puede ser no entera. Establezca _fuerza_ en 0 (cero) para desactivar el efecto. Con cuidado, que configurar _fuerza_ demasiado alto puede requerir mucho tiempo de CPU para renderizar.
 
 Tenga en cuenta que esta etiqueta difumina solo los _bordes_ del texto, no todo. Esto significa que si el texto tiene un borde (establecido con [`\bord`]({{<relref path="ASS_Tags#\bord">}})) el borde se verá borroso, pero si no hay borde, el texto principal aparecerá borroso.
 
-{{<tag-def-box title="Nombre de fuente" id="\fn">}}\\fn<i>\<nombre></i>{{</tag-def-box>}}
+{{%tag-def-box title="Nombre de fuente"%}}\\fn<i>\<nombre></i>{{%/tag-def-box%}}
 Establece la fuente que se utilizará para el texto que sigue. No debe haber ningún espacio entre `\fn` y el nombre de la fuente, y tampoco puede poner paréntesis o algo similar alrededor del nombre de la fuente.
 
 {{<example-box>}}
@@ -168,7 +168,7 @@ El texto que sigue a esta etiqueta estará en fuente Arial.
 El texto que sigue a esta etiqueta estará en fuente Times New Roman.
 {{</example-box>}}
 
-{{<tag-def-box title="Tamaño de fuente" id="\fs">}}\\fs<i>\<tamaño></i>{{</tag-def-box>}}
+{{%tag-def-box title="Tamaño de fuente"%}}\\fs<i>\<tamaño></i>{{%/tag-def-box%}}
 Establece el tamaño de la fuente. El tamaño especificado es la altura en píxeles de escritura, por lo que con un tamaño de fuente 40, una línea de texto tiene 40 píxeles de alto. (Nota técnica: en realidad se trata de puntos tipográficos (edición de escritorio), no de píxeles de guion, pero dado que la representación siempre se realiza a 72 DPI (según el estándar de facto), un punto termina siendo exactamente igual a un píxel de resolución de guion).
 
 Sólo puede especificar tamaños de fuente enteros.
@@ -182,10 +182,10 @@ Sólo puede especificar tamaños de fuente enteros.
 El siguiente texto será de una fuente de tamaño 10.
 {{</example-box>}}
 
-{{<tag-def-box title="Escala de fuente" id="\fscx">}}
+{{%tag-def-box title="Escala de fuente"%}}
 \\fscx<i>\<escala></i>
 \\fscy<i>\<escala></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Ajusta el tamaño del texto en dirección X (`\fscx` o Y (`\fscy`). La _escala_ dada está en porcentaje, por lo que 100 significa "tamaño original".
 
 Esto no es lo mismo que configurar el tamaño de fuente, ya que configurar el tamaño está sujeto a [sugerencias de fuente](http://en.wikipedia.org/wiki/Font_hinting), mientras que escalar el texto modifica la forma del texto después de la sugerencia. Como resultado, esto siempre debe usarse con `\t` en lugar de `\fs`, ya que la animación de cambio de sugerencias para fuentes muy rara vez es deseable.
@@ -221,17 +221,17 @@ Disminuye el texto a media altura.
 Duplica el tamaño del texto.
 {{</example-box>}}
 
-{{<tag-def-box title="Espaciado entre letras" id="\fsp">}}\\fsp<i>\<espaciado></i>{{</tag-def-box>}}
+{{%tag-def-box title="Espaciado entre letras"%}}\\fsp<i>\<espaciado></i>{{%/tag-def-box%}}
 Cambia el espacio entre las letras individuales del texto. Puede utilizar esto para separar el texto más visualmente. El _espaciado_ se proporciona en píxeles de resolución de guion.
 
 El espaciado puede ser negativo y tener decimales.
 
-{{<tag-def-box title="Rotación de texto" id="\frx">}}
+{{%tag-def-box title="Rotación de texto"%}}
 \\frx<i>\<cantidad></i>
 \\fry<i>\<cantidad></i>
 \\frz<i>\<cantidad></i>
 \\fr<i>\<cantidad></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Gira el texto alrededor del eje X, Y o Z. La etiqueta `\fr` es un atajo para `\frz`.
 
 - El **eje X** corre horizontalmente por la pantalla. Girando sobre él (con valores positivos) provoca un efecto con que la parte superior del texto se mete hacia "adentro" de la pantalla mientras que la parte inferior sale hacia "afuera" de la pantalla.
@@ -296,10 +296,10 @@ Los siguientes pantallazos demuestran el efecto de girar sobre los diferentes ej
 ![Fr_sample03](/img/3.2/Fr_sample03.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="Cizallamiento de texto" id="\fax">}}
+{{%tag-def-box title="Cizallamiento de texto"%}}
 \\fax<i>\<factor></i>
 \\fay<i>\<factor></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Realiza una transformación de cizallamiento (corte, transvección) del texto. Un _factor_ de 0 (cero) significa que no hay distorsión.
 
 Por lo general, _factor_ será un número pequeño; es poco probable que los valores fuera del rango -2 a 2 produzcan resultados deseables.
@@ -310,7 +310,7 @@ El corte se realiza después de la rotación, en las coordenadas giradas. El sis
 ![cizallamiento](/img/3.2/shearing.png)
 {{</example-box>}}
 
-{{<tag-def-box title="Codificación de fuente" id="\fe">}}\\fe<i>\<id></i>{{</tag-def-box>}}
+{{%tag-def-box title="Codificación de fuente"%}}\\fe<i>\<id></i>{{%/tag-def-box%}}
 Configura la codificación de fuente Windows utilizada para seleccionar la tabla de mapeo de fuentes utilizado para traducir puntos Unicode a índices de glifos en la fuente. Para algunas fuentes sin una tabla de mapeo Unicode, esto puede ser necesario para que funcione el texto en ciertos idiomas. Para las fuentes que tienen una tabla de mapeo Unicode, se podría usar para seleccionar variaciones regionales, como elegir el glifo correcto para un ideograma Han que sea diferente en chino simplificado, chino tradicional, japonés y coreano.
 
 Algunos ID de codificación de fuentes comunes son:
@@ -333,13 +333,13 @@ Una lista más completa se puede ver en la caja de diálogo del [editor de estil
 
 En archivos ASS almacenados en codificaciones que no son Unicode, esta etiqueta también afecta en qué página de códigos debe interpretarse el texto que le sigue. Aegisub no soporta este uso y es posible que algunos renderizadores tampoco lo admitan. Se recomienda que no confíe en esto y, en su lugar, almacene siempre sus archivos en codificación Unicode. (Aegisub almacena archivos en Unicode UTF-8 por defecto).
 
-{{<tag-def-box title="Establecer color" id="\c">}}
+{{%tag-def-box title="Establecer color"%}}
 \\c&H<i>\<bb>\<gg>\<rr></i>&
 \\1c&H<i>\<bb>\<gg>\<rr></i>&
 \\2c&H<i>\<bb>\<gg>\<rr></i>&
 \\3c&H<i>\<bb>\<gg>\<rr></i>&
 \\4c&H<i>\<bb>\<gg>\<rr></i>&
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Establece el color del siguiente texto. La etiqueta `\c` es una abreviatura de `\1c`.
 
 - `\1c` establece el color de relleno principal.
@@ -351,13 +351,13 @@ Los códigos de color se dan en [hexadecimal](http://en.wikipedia.org/wiki/Hexad
 
 Los botones Seleccionar Color de la barra de herramientas ![pick-color-toolbar-buttons](/img/3.2/pick-color-toolbar-buttons.png) pueden ayudar a seleccionar colores e ingresar los códigos de color.
 
-{{<tag-def-box title="Establecer alfa" id="\alpha">}}
+{{%tag-def-box title="Establecer alfa"%}}
 \\alpha&H<i>\<aa></i>
 \\1a&H<i>\<aa></i>
 \\2a&H<i>\<aa></i>
 \\3a&H<i>\<aa></i>
 \\4a&H<i>\<aa></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Establece el alfa (transparencia) del texto.
 
 - `\alpha` establece el alfa de todos los componentes a la vez.
@@ -385,7 +385,7 @@ Fija el alfa de todos los componentes en hexadecimal 80, decimal 128, para que e
 Fija el alfa de relleno principal en hexadecimal FF, decimal 255, para que resulte efectivamente invisible dejando solo el borde y la sombra.
 {{</example-box>}}
 
-{{<tag-def-box title="Alineación de línea" id="\an">}}\\an<i>\<pos></i>{{</tag-def-box>}}
+{{%tag-def-box title="Alineación de línea"%}}\\an<i>\<pos></i>{{%/tag-def-box%}}
 Especifica la alineación de la línea. La alineación define la posición de la línea cuando no hay ni [anulación de posición]({{<relref path="ASS_Tags#\pos">}}) ni [movimiento]({{<relref path="ASS_Tags#\move">}}) en efecto. De lo contrario, especifica el punto de anclaje de posicionamiento y rotación.
 
 La etiqueta `\an` usa valores del "teclado numérico" ("numpad") para _pos_. Es decir, los valores de alineación corresponden a las posiciones de los dígitos en el teclado numérico de cuadrícula:
@@ -400,7 +400,7 @@ La etiqueta `\an` usa valores del "teclado numérico" ("numpad") para _pos_. Es 
 1. Arriba centro
 1. Arriba derecha
 
-{{<tag-def-box title="Alineación de línea (antigua)" id="\a">}}\\a<i>\<pos></i>{{</tag-def-box>}}
+{{%tag-def-box title="Alineación de línea (antigua)"%}}\\a<i>\<pos></i>{{%/tag-def-box%}}
 Especifica la alineación de la línea utilizando códigos de alineación heredados de SubStation Alpha. Esta etiqueta es compatible pero se considera obsoleta; normalmente uno debe usar `\an` en nuevos guiones, ya que es más intuitivo.
 
 La excepción es que `\a6` debería usarse para la traducción perezosa de signos, porque si uno va a ser holgazán ha de hacerlo bien y ahorrar la letra extra.
@@ -417,12 +417,12 @@ Calcule _pos_ de la siguiente manera: use 1 para alineación a la izquierda, 2 p
 - 10: Centro
 - 11: Centro derecha
 
-{{<tag-def-box title="Efecto Karaoke" id="\k">}}
+{{%tag-def-box title="Efecto Karaoke"%}}
 \\k<i>\<duración></i>
 \\K<i>\<duración></i>
 \\kf<i>\<duración></i>
 \\ko<i>\<duración></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 
 > _Tenga en cuenta que estas etiquetas por sí solas solo crean algunos efectos muy específicos
 > y todos los demás efectos se crean con una combinación de múltiples diferentes
@@ -440,7 +440,7 @@ Las diferentes etiquetas `\k` crean varios efectos:
 
 _Nota: Hay una etiqueta de karaoke adicional, `\kt`, que es muy diferente a las demás. Rara vez es útil y Aegisub no soporta esa etiqueta; por lo tanto no está documentada._
 
-{{<tag-def-box title="Estilo de salto" id="\q">}}\\q<i>\<estilo></i>{{</tag-def-box>}}
+{{%tag-def-box title="Estilo de salto"%}}\\q<i>\<estilo></i>{{%/tag-def-box%}}
 
 Determina cómo se aplica el salto de línea a la línea de subtítulo. Los siguientes \_estilo_s están disponibles:
 
@@ -449,7 +449,7 @@ Determina cómo se aplica el salto de línea a la línea de subtítulo. Los sigu
 - 2: Sin ajuste, las líneas anchas se extenderán más allá de los bordes de la pantalla. Tanto `\n` como `\N` fuerzan saltos de línea.
 - 3: Salto/ajuste inteligente, similar al estilo 0, pero las líneas inferiores se hacen más anchas.
 
-{{<tag-def-box title="Restablecer estilo" id="\r">}}\\r<br>\\r<i>\<estilo></i>{{</tag-def-box>}}
+{{%tag-def-box title="Restablecer estilo"%}}\\r<br>\\r<i>\<estilo></i>{{%/tag-def-box%}}
 Restablece el estilo. Esto cancela todas las anulaciones de estilo vigentes, incluidas
 [animaciones]({{<relref path="ASS_Tags#\t">}}), para todo el texto siguiente.
 
@@ -464,7 +464,7 @@ La primera forma que no especifica un _estilo_ restablecerá al estilo definido 
 Suponiendo que el estilo de línea actual es "Default", primero tiene "Hey" en el estilo predeterminado y luego sigue en la siguiente línea "Huh?" en el estilo "Alternate", y en la tercera línea el estilo se restablece a "Default" para "Who are you?"
 {{</example-box>}}
 
-{{<tag-def-box title="Fijar posición" id="\pos">}}\\pos(<i>\<X></i>,<i>\<Y></i>){{</tag-def-box>}}
+{{%tag-def-box title="Fijar posición"%}}\\pos(<i>\<X></i>,<i>\<Y></i>){{%/tag-def-box%}}
 Establece la posición de la línea. Las coordenadas _X_ y _Y_ deben ser números enteros y se proporcionan en el sistema de coordenadas de resolución de guion. El significado de _X_ y _Y_ cambia ligeramente dependiendo de la [alineación]({{<relref path="ASS_Tags#\an">}}).
 
 La alineación de la línea de subtítulo se utiliza como punto de anclaje para la posición. Es decir, cuando tiene una línea con alineación arriba-izquierda, la esquina superior izquierda del subtítulo se coloca en las coordenadas dadas a `\pos`, y para la alineación abajo-centro, el centro inferior del subtítulo se coloca en las coordenadas dadas.
@@ -477,10 +477,10 @@ Las siguientes capturas de pantalla demuestran la forma de que la alineación af
 ![Pos_sample03](/img/3.2/Pos_sample03.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="Movimiento" id="\move">}}
+{{%tag-def-box title="Movimiento"%}}
 \\move(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i> >)
 \\move(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i> >,<i>\<t1</i>>,<i>\<t2</i>>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 La etiqueta `\move` funciona de manera similar a [`\pos`]({{<relref path="ASS_Tags#\pos">}}) en que posiciona la línea de subtítulo, la diferencia es que `\ move` hace que el subtítulo se mueva.
 
 Las dos versiones de `\move` se diferencian en que una hace que el movimiento se produzca durante toda la duración del subtítulo, mientras que la otra especifica el tiempo durante el cual se produce el movimiento.
@@ -521,7 +521,7 @@ Cuando aparece la línea en la pantalla, el subtítulo está en (100,150). Mient
 La línea aparece en (100,150). Después de que la línea haya aparecido durante medio segundo (500 milisegundos), comienza a moverse hacia (300,350), de modo que llegará al punto un segundo y medio (1500 milisegundos) después de que la línea apareció por primera vez en la pantalla.
 {{</example-box>}}
 
-{{<tag-def-box title="Origen de rotación" id="\org">}}\\org(<i>\<X></i>,<i>\<Y></i> ){{</tag-def-box>}}
+{{%tag-def-box title="Origen de rotación"%}}\\org(<i>\<X></i>,<i>\<Y></i> ){{%/tag-def-box%}}
 Establece el punto de origen utilizado para [rotación]({{<relref path="ASS_Tags#\frx">}}). Esto afecta a todas las rotaciones de la línea. Las coordenadas _X_ y _Y_ se proporcionan en números enteros de píxeles de resolución de guion.
 
 Cuando no hay una etiqueta `\org` en una línea, el origen de rotación es implícitamente el mismo que el [punto de anclaje de posición]({{<relref path="ASS_Tags#\pos">}}). Esto significa que el origen de la rotación se moverá si la línea se mueve y no hay un origen establecido con `\org`. Tenga en cuenta que _no_ puede animar la etiqueta `\org`, está limitado a un origen fijo si la usa.
@@ -549,7 +549,7 @@ Fija el origen de rotación en el punto (320,240).
 Colocar el origen de rotación en un punto lejano le permite utilizar ligeras rotaciones `\frz` para producir efectos de "salto"; el texto se moverá hacia arriba o hacia abajo sin que parezca girar.
 {{</example-box>}}
 
-{{<tag-def-box title="Desvanecimiento" id="\fad">}}\\fad(<i>\<entrada></i>,<i>\<salida></i>) {{</tag-def-box>}}
+{{%tag-def-box title="Desvanecimiento"%}}\\fad(<i>\<entrada></i>,<i>\<salida></i>) {{%/tag-def-box%}}
 Produce un efecto de aparición y desaparición gradual. Los tiempos de _entrada_ y _salida_ se dan en milisegundos; es decir, 1000 significa un segundo. Puede especificar _entrada_ o _salida_ como 0 (cero) para no tener ningún efecto de desvanecimiento en ese extremo.
 
 Agregar un efecto de desvanecimiento no extiende la duración de la línea, sino que se usa el inicio o el final del tiempo visible de la línea para el efecto de desvanecimiento. Por esta razón, debes tener cuidado de que _entrada_+_salida_ no sea mayor que la duración de la línea. Por ejemplo, para una línea que aparece durante 4 segundos, la suma de _entrada_+_salida_ no debe ser mayor que 4000.
@@ -563,7 +563,7 @@ Agregar un efecto de desvanecimiento no extiende la duración de la línea, sino
 Aparece gradualmente la línea en los primeros 1,2 segundos que está visible y se desvanece durante el último cuarto de segundo visible.
 {{</example-box>}}
 
-{{<tag-def-box title="Desvanecimiento (complejo)" id="\fade">}}\\fade(<i>\<a1</i>>,<i>\<a2</i>>,<i>\<a3</i>>,<i>\<t1</i>>,<i>\<t2</i>>,<i>\<t3</i>> ,<i>\<t4</i>>){{</tag-def-box>}}
+{{%tag-def-box title="Desvanecimiento (complejo)"%}}\\fade(<i>\<a1</i>>,<i>\<a2</i>>,<i>\<a3</i>>,<i>\<t1</i>>,<i>\<t2</i>>,<i>\<t3</i>> ,<i>\<t4</i>>){{%/tag-def-box%}}
 Realice un desvanecimiento de cinco partes utilizando tres valores alfa _a1_, _a2_ y _a3_ y cuatro tiempos _t1_, _t2_, _t3_ y _t4_.
 
 Los valores alfa se dan en _decimal_ y están entre 0 y 255, siendo 0 completamente visible y 255 invisible. Los valores de tiempo se dan en milisegundos después del inicio de la línea. Se requieren los siete parámetros.
@@ -584,12 +584,12 @@ Los valores alfa se dan en _decimal_ y están entre 0 y 255, siendo 0 completame
 Comienza invisible, se materializa hasta volverse casi totalmente opaco y luego se desvanece hasta volverse casi totalmente invisible. El primer desvanecimiento comienza cuando comienza la línea y dura 500 milisegundos. El segundo desvanecimiento comienza a los 1500 milisegundos más tarde y dura 200 milisegundos.
 {{</example-box>}}
 
-{{<tag-def-box title="Transformación animada" id="\t">}}
+{{%tag-def-box title="Transformación animada"%}}
 \\t(<i>\<estilos></i>)
 \\t(<i>\<acel></i>,<i>\<estilos></i>)
 \\t(<i>\<t1</i>>,<i>\<t2</i>>,<i>\<estilos></i>)
 \\t(<i>\<t1</i>>,<i>\<t2</i>>,<i>\<acel></i>,<i>\<estilos></i>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 
 Realiza una transformación gradual y animada de un estilo a otro. Los _estilos_ son otras etiquetas manuales como se especifica en esta referencia. Sólo un conjunto limitado de etiquetas manuales se pueden animar con `\t`:
 
@@ -651,10 +651,10 @@ Igual que el anterior, pero comenzará rápido y disminuirá, aún haciendo las 
 El texto comienza con un tamaño cero, es decir, invisible, y luego crece hasta alcanzar el 100% del tamaño tanto en la dirección X como en la Y.
 {{</example-box>}}
 
-{{<tag-def-box title="Clip (rectángulo)" id="\clip">}}
+{{%tag-def-box title="Clip (rectángulo)"%}}
 \\clip(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i> >)
 \\iclip(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i> >)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Define un rectángulo para recortar la línea; solo la parte de la línea que está dentro del rectángulo será visible. La etiqueta `\iclip` tiene el efecto contrario: define un rectángulo donde no se ve la línea.
 
 Las coordenadas _x1_, _y1_, _x2_ y _y2_ se dan en píxeles de resolución de guion y son relativas a la esquina superior izquierda del vídeo. Las coordenadas deben ser números enteros, no hay posibilidad de utilizar coordenadas no enteras. (Aumentar la resolución del guion no aumentará la precisión; el recorte siempre ocurre en los límites de los píxeles del video).
@@ -681,12 +681,12 @@ Ejemplo de `\clip(0,0,704,245)` en un vídeo de 704x480:
 ![Clip_sample01](/img/3.2/Clip_sample01.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="Clip (dibujo vectorial)" id="\clip-vector">}}
+{{%tag-def-box title="Clip (dibujo vectorial)"%}}
 \\clip(<i>\<comandos de dibujo></i>)
 \\clip(<i>\<escala></i>,<i>\<comandos de dibujo></i>)
 \\iclip(<i>\<comandos de dibujo></i>)
 \\iclip(<i>\<escala></i>,<i>\<comandos de dibujo></i>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Usa la forma definida como dibujo vectorial para mostrar selectivamente (`\clip`) u ocultar (`\iclip`) partes de la línea.
 
 Los _comandos de dibujo_ son comandos de dibujo como los que se usan con la etiqueta `\p`. Las coordenadas se dan en píxeles de resolución de guion y son relativas a la esquina superior izquierda del video.

--- a/content/zh-cn/docs/latest/ASS_Tags.md
+++ b/content/zh-cn/docs/latest/ASS_Tags.md
@@ -20,7 +20,7 @@ override blocks (i.e. not between { and }).
 
 下列标签写在文本中，而不是特效区域中（即不在 { 和 } 中）。
 
-{{<tag-def-box title="软换行（软空格)" id="\n">}}\\n{{</tag-def-box>}}
+{{%tag-def-box title="软换行（软空格)"%}}\\n{{%/tag-def-box%}}
 Insert a forced line break, but only when in wrapping mode 2. (See
 [the \\q tag]({{< relref "ASS_Tags#wrapstyle" >}})). Note that this is a lowercase n.
 
@@ -34,13 +34,13 @@ rarely (if ever) actually useful. If you're not sure whether you want this or
 在所有其他的换行方式下，它被当作一个空格对待。这个真的不常用（即使用过）。如果你不确定你想要的效果的是
 \\n 还是 \\N ，那么十有八九是 \\N。
 
-{{<tag-def-box title="硬换行符" id="\N">}}\\N{{</tag-def-box>}}
+{{%tag-def-box title="硬换行符"%}}\\N{{%/tag-def-box%}}
 Insert a forced line break, regardless of wrapping mode. Note that this is an
 uppercase N.
 
 插入一个强制换行符，在所有换行方式下都生效。注意这是一个大写的 N。
 
-{{<tag-def-box title="硬空格" id="\h">}}\\h{{</tag-def-box>}}
+{{%tag-def-box title="硬空格"%}}\\h{{%/tag-def-box%}}
 Insert a non-breaking "hard" space. The line will never break automatically
 right before or after a hard space, and hard spaces are not folded when they
 appear at the start or end of a displayed line.
@@ -103,21 +103,21 @@ all tags in how they look.
 在这一页，所有在 `<`尖括号`>` 中的 *斜体*
 文字都是参数，需要你用数值代替。尖括号不需要输入，直接输入数值即可。下面的例子将引导你来了解如何设定这些标签的参数。通常情况下，在它们的外观上，相同的规则应用于所有的标签。（译者注：这里的规则指的应该就是数值要写在标签的后面）
 
-{{<tag-def-box title="斜体" id="\i">}}
+{{%tag-def-box title="斜体"%}}
 \\i1
 \\i0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch _italics_ text on or off. Use `\i1` to enable italics for the following
 text and `\i0` to disable italics again.
 
 打开或关闭 *斜体*
 选项。利用`\i1`对后面的字符应用斜体，并且可以用`\i0`使后面的字符取消斜体。
 
-{{<tag-def-box title="粗体" id="\b">}}
+{{%tag-def-box title="粗体"%}}
 \\b1
 \\b0
 \\b<i>\<weight></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch **boldface** text on or off. Use `\b1` to enable boldface for the
 following text and `\b0` to disable boldface again.
 
@@ -157,27 +157,27 @@ to see "not bold" and "bold" in that case.
 
 {{</example-box>}}
 
-{{<tag-def-box title="下划线" id="\u">}}
+{{%tag-def-box title="下划线"%}}
 \\u1
 \\u0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch <u>underlined</u> text on or off. Use `\u1` to enable underlining for
 the following text and `\u0` to disable underlining again.
 
 打开或关闭 <u>\_\_下划线</u>
 选项。利用`\u1`对后面的字符应用下划线，并且可以用`\u0`使后面的字符取消下划线。
 
-{{<tag-def-box title="删除线" id="\s">}}
+{{%tag-def-box title="删除线"%}}
 \\s1
 \\s0
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Switch <s>striked out</s> text on or off. Use `\s1` to enable strikeout for
 the following text and `\s0` to disable strikeout again.
 
 打开或关闭 ~~删除线~~
 选项。利用`\s1`对后面的字符应用删除线，并且可以用`\s0`使后面的字符取消删除线。
 
-{{<tag-def-box title="边框宽度" id="\bord">}}\\bord<i>\<size></i>{{</tag-def-box>}}
+{{%tag-def-box title="边框宽度"%}}\\bord<i>\<size></i>{{%/tag-def-box%}}
 Change the width of the border around the text. Set the size to 0 (zero) to
 disable the border entirely.
 
@@ -213,10 +213,10 @@ Disable border entirely. 完全隐藏边框。
 Set the border width to 3.7 pixels 设置边框宽度为3.7个像素
 {{</example-box>}}
 
-{{<tag-def-box title="边框宽度 (补充)" id="\xbord">}}
+{{%tag-def-box title="边框宽度 (补充)"%}}
 \\xbord<i>\<size></i>
 \\ybord<i>\<size></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Use the `\xbord` `\ybord` tags to set the border size in X and Y direction
 separately. This can be useful for correcting the border size for anamorphic
 rendering of subtitles.
@@ -235,7 +235,7 @@ disable border in that direction.
 
 你可以把某个方向上的边框宽度设为0，这个方向的边框就完全消失。
 
-{{<tag-def-box title="阴影距离" id="\shad">}}\\shad<i>\<depth></i>{{</tag-def-box>}}
+{{%tag-def-box title="阴影距离"%}}\\shad<i>\<depth></i>{{%/tag-def-box%}}
 Set the distance from the text to position the shadow. Set the depth to 0
 (zero) to disable shadow entirely. Works similar to [\\bord]({{< relref "ASS_Tags#bordersize" >}}).
 
@@ -245,10 +245,10 @@ The shadow distance can not be negative with this tag.
 
 阴影距离也不能设置为负数值。
 
-{{<tag-def-box title="阴影距离 (补充)" id="\xshad">}}
+{{%tag-def-box title="阴影距离 (补充)"%}}
 \\xshad<i>\<depth></i>
 \\yshad<i>\<depth></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Set the distance from the text to position the shadow at, with X and Y
 position set separately. Shadow is only disabled if both X and Y distance is
 0\.
@@ -260,11 +260,11 @@ position the shadow to the top or left of the text.
 
 注意它和`\shad`不同，你可以设置距离值为负数让阴影显示在字符的上方或者左方。
 
-{{<tag-def-box title="边框模糊" id="\be">}}
+{{%tag-def-box title="边框模糊"%}}
 \\be0
 \\be1
 \\be<i>\<strength></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Enable or disable a subtle softening-effect for the edges of the text. The
 effect isn't always very visible, but it can in some cases make the text look
 better. It is usually more visible at smaller text sizes.
@@ -289,7 +289,7 @@ generally more useful as a result. The _strength_ must be an integer number.
 是循环叠加效果的次数。注意数值给的比较大的时候就会把边框整个糊掉，并且通常情况下并没有什么卵用。对于高强度模糊，`\blur`通常结果更有用。
 *strength* 必须是一个整数。
 
-{{<tag-def-box title="边缘模糊 (高斯函数)" id="\blur">}}\\blur<i>\<strength></i>{{</tag-def-box>}}
+{{%tag-def-box title="边缘模糊 (高斯函数)"%}}\\blur<i>\<strength></i>{{%/tag-def-box%}}
 In general, this has the same function as the [`\be`]({{< relref "ASS_Tags#bluredges" >}}) tag, but
 uses a more advanced algorithm that looks better at high strengths. Unlike
 `\be`, the _strength_ can be non-integer here. Set _strength_ to 0 (zero) to
@@ -308,7 +308,7 @@ blurred instead.
 注意，这个标签会模糊文本的 *边框*
 ，不是全部。也就是说，如果文本有边框（用[\`\\bord\`]({{< relref "ASS_Tags#borderwidth" >}})标签进行设置），那么边框会被模糊，但是如果没有边框，那么文本的主体就会被模糊。
 
-{{<tag-def-box title="字体名称" id="\fn">}}\\fn<i>\<字体名称></i>{{</tag-def-box>}}
+{{%tag-def-box title="字体名称"%}}\\fn<i>\<字体名称></i>{{%/tag-def-box%}}
 Set the font face to use for the following text. There should be no space
 between `\fn` and the font name, and you should not put parentheses or similar
 around the font name either.
@@ -338,7 +338,7 @@ The text following this tag will be in Times New Roman font.
 
 {{</example-box>}}
 
-{{<tag-def-box title="字体大小" id="\fs">}}\\fs<i>\<大小></i>{{</tag-def-box>}}
+{{%tag-def-box title="字体大小"%}}\\fs<i>\<大小></i>{{%/tag-def-box%}}
 Set the size of the font. The size specified is the height in script pixels,
 so at font size 40 one line of text is 40 pixels tall. (Technical note: it's
 really typographic (desktop publishing) points, not script pixels, but since
@@ -364,10 +364,10 @@ The following text will use a size 10 font.
 
 {{</example-box>}}
 
-{{<tag-def-box title="Font scale" id="\fscx">}}
+{{%tag-def-box title="Font scale"%}}
 \\fscx<i>\<scale></i>
 \\fscy<i>\<scale></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Adjust the size of the text in X (`\fscx` or Y (`\fscy`) direction. The
 _scale_ given is in percent, so 100 means "original size".
 
@@ -431,7 +431,7 @@ Make the text double size.
 
 {{</example-box>}}
 
-{{<tag-def-box title="Letter spacing" id="\fsp">}}\\fsp<i>\<spacing></i>{{</tag-def-box>}}
+{{%tag-def-box title="Letter spacing"%}}\\fsp<i>\<spacing></i>{{%/tag-def-box%}}
 Changes the spacing between the individual letters in the text. You can use
 this to spread the text more out visually. The _spacing_ is given in script
 resolution pixels.
@@ -443,12 +443,12 @@ Spacing can be negative and can have decimals.
 
 间距可以是负值，也可以含有小数。
 
-{{<tag-def-box title="文本旋转" id="\frx">}}
+{{%tag-def-box title="文本旋转"%}}
 \\frx<i>\<amount></i>
 \\fry<i>\<amount></i>
 \\frz<i>\<amount></i>
 \\fr<i>\<amount></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Rotates the text along the X, Y or Z axis. The `\fr` tag is a shortcut for `\frz`.
 
 沿 X，Y，Z 轴旋转文本。`\fr`标签是`\frz`的简写。
@@ -545,10 +545,10 @@ The following screenshots illustrate the effect of rotating on the different axe
 ![Fr_sample03](/img/3.2/Fr_sample03.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="文本剪切变换" id="\fax">}}
+{{%tag-def-box title="文本剪切变换"%}}
 \\fax<i>\<factor></i>
 \\fay<i>\<factor></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Perform a shearing (perspective distortion) transformation of the text. A
 _factor_ of 0 (zero) means no distortion.
 
@@ -570,7 +570,7 @@ coordinate system used for shearing is not affected by the [rotation origin]({{<
 ![shearing](/img/3.2/shearing.png)
 {{</example-box>}}
 
-{{<tag-def-box title="字体字符集" id="\fe">}}\\fe<i>\<id></i>{{</tag-def-box>}}
+{{%tag-def-box title="字体字符集"%}}\\fe<i>\<id></i>{{%/tag-def-box%}}
 Set the Windows font encoding used to select the font mapping table used to
 translate Unicode codepoints to glyph indices in the font. For some fonts
 without a Unicode mapping table this might be required to get text in certain
@@ -633,13 +633,13 @@ Unicode encoding. (Aegisub stores files in Unicode UTF-8 by default.)
 不支持这个用法，一些渲染器可能也不支持。所以建议你不要依赖这个功能，而是始终以
 Unicode 编码保存 ASS 文件。（Aegisub 保存 ASS 文件的默认编码是 UTF-8）
 
-{{<tag-def-box title="设置颜色" id="\c">}}
+{{%tag-def-box title="设置颜色"%}}
 \\c&H<i>\<bb>\<gg>\<rr></i>&
 \\1c&H<i>\<bb>\<gg>\<rr></i>&
 \\2c&H<i>\<bb>\<gg>\<rr></i>&
 \\3c&H<i>\<bb>\<gg>\<rr></i>&
 \\4c&H<i>\<bb>\<gg>\<rr></i>&
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Set the color of the following text. The `\c` tag is an abbreviation of `\1c`.
 
 设置其后字符的颜色。`\c` 标签是 `\1c` 的缩写。
@@ -667,13 +667,13 @@ assist in picking colors and entering the color codes.
 
 取色器工具栏按钮![pick-color-toolbar-buttons](/img/3.2/pick-color-toolbar-buttons.png)可以帮助你选择颜色和填写颜色代码。
 
-{{<tag-def-box title="设置透明度" id="\alpha">}}
+{{%tag-def-box title="设置透明度"%}}
 \\alpha&H<i>\<aa></i>
 \\1a&H<i>\<aa></i>
 \\2a&H<i>\<aa></i>
 \\3a&H<i>\<aa></i>
 \\4a&H<i>\<aa></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Set the alpha (transparency) of the text. 设置字符的透明度。
 
 - `\alpha` sets the alpha of all components at once.
@@ -716,7 +716,7 @@ and effectively leaving only the border and shadow.
 设置主要填充透明度为十六进制的FF，十进制的255，即完全不透明。这时只能看见边框和阴影。
 {{</example-box>}}
 
-{{<tag-def-box title="行对齐方式" id="\an">}}\\an<i>\<pos></i>{{</tag-def-box>}}
+{{%tag-def-box title="行对齐方式"%}}\\an<i>\<pos></i>{{%/tag-def-box%}}
 Specify the alignment of the line. The alignment specifies the position of the
 line when no [position override]({{< relref "ASS_Tags#setposition" >}}) or
 [movement]({{< relref "ASS_Tags#movement" >}}) is in effect, and otherwise specifies the
@@ -755,7 +755,7 @@ keyboard:
 1. 屏幕顶部中间
 1. 屏幕右上角
 
-{{<tag-def-box title="行对齐方式 (传统)" id="\a">}}\\a<i>\<pos></i>{{</tag-def-box>}}
+{{%tag-def-box title="行对齐方式 (传统)"%}}\\a<i>\<pos></i>{{%/tag-def-box%}}
 Specify the alignment of the line using legacy alignment codes from SubStation
 Alpha. This tag is supported but considered deprecated; you should usually use
 `\an` in new scripts instead, as it is more intuitive.
@@ -799,12 +799,12 @@ top-titles, add 4 to the number, to get mid-titles add 8 to the number:
 - 10：屏幕正中央
 - 11：屏幕中间右侧
 
-{{<tag-def-box title="卡拉OK 效果" id="\k">}}
+{{%tag-def-box title="卡拉OK 效果"%}}
 \\k<i>\<duration></i>
 \\K<i>\<duration></i>
 \\kf<i>\<duration></i>
 \\ko<i>\<duration></i>
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 
 > _Please note that these tags alone only create some very specific effects
 > and all other effects are created with a combination of multiple different
@@ -852,7 +852,7 @@ it is not documented._
 *注意：还有一个额外的卡拉OK 标签，`\kt`。它和其他卡拉OK
 标签十分不同。因为它很少用到，Aegisub 也不支持它，所以这里就不说他了。*
 
-{{<tag-def-box title="换行风格" id="\q">}}\\q<i>\<style></i>{{</tag-def-box>}}
+{{%tag-def-box title="换行风格"%}}\\q<i>\<style></i>{{%/tag-def-box%}}
 Determine how line breaking is applied to the subtitle line. The following
 \_style_s are available:
 
@@ -870,7 +870,7 @@ Determine how line breaking is applied to the subtitle line. The following
 - 2：不换行，多余的字符会超过屏幕边缘。遇到`\n`和`\N`都会强制换行。
 - 3：智能换行，与参数1相似，但是会选择让靠近底部的行更宽。
 
-{{<tag-def-box title="重置样式" id="\r">}}\\r<br>\\r<i>\<style></i>{{</tag-def-box>}}
+{{%tag-def-box title="重置样式"%}}\\r<br>\\r<i>\<style></i>{{%/tag-def-box%}}
 Reset the style. This cancels all style overrides in effect, including
 [animations]({{< relref "ASS_Tags#animatedtransform" >}}), for all following text.
 
@@ -901,7 +901,7 @@ are you?"又被重设为 Default 样式。
 
 {{</example-box>}}
 
-{{<tag-def-box title="位置设定" id="\pos">}}\\pos(<i>\<X></i>,<i>\<Y></i>){{</tag-def-box>}}
+{{%tag-def-box title="位置设定"%}}\\pos(<i>\<X></i>,<i>\<Y></i>){{%/tag-def-box%}}
 Set the position of the line. The _X_ and _Y_ coordinates must be integers and
 are given in the script resolution coordinate system. The meaning of _X_ and
 _Y_ changes slightly depending on [alignment]({{< relref "ASS_Tags#linealignment" >}}).
@@ -932,10 +932,10 @@ The green cross marks the point (320,240) on the video.
 ![Pos_sample03](/img/3.2/Pos_sample03.jpg)
 {{</example-box>}}
 
-{{<tag-def-box title="移动设定" id="\move">}}
+{{%tag-def-box title="移动设定"%}}
 \\move(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>)
 \\move(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>,<i>\<t1</i>>,<i>\<t2</i>>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 The `\move` tag works similar to [`\pos`]({{< relref "ASS_Tags#setposition" >}}) in that it
 positions the subtitle line, the difference is that `\move` makes the subtitle
 move.
@@ -1036,7 +1036,7 @@ first appeared on screen.
 150)。在被显示0.5秒后，它开始移动，在被显示1.5秒时移动到 (300, 350)。
 {{</example-box>}}
 
-{{<tag-def-box title="旋转中心" id="\org">}}\\org(<i>\<X></i>,<i>\<Y></i>){{</tag-def-box>}}
+{{%tag-def-box title="旋转中心"%}}\\org(<i>\<X></i>,<i>\<Y></i>){{%/tag-def-box%}}
 Set the origin point used for [rotation]({{< relref "ASS_Tags#textrotation" >}}). This
 affects all rotations of the line. The _X_ and _Y_ coordinates are given in
 integer script resolution pixels.
@@ -1099,7 +1099,7 @@ without seeming to rotate.
 旋转会看起来像"跳跃"效果，文本将上下移动，但是看起来并不像旋转。
 {{</example-box>}}
 
-{{<tag-def-box title="渐变" id="\fad">}}\\fad(<i>\<fadein></i>,<i>\<fadeout></i>){{</tag-def-box>}}
+{{%tag-def-box title="渐变"%}}\\fad(<i>\<fadein></i>,<i>\<fadeout></i>){{%/tag-def-box%}}
 Produce a fade-in and fade-out effect. The _fadein_ and _fadeout_ times are
 given in milliseconds, ie. 1000 means one second. You can specify _fadein_ or
 _fadeout_ as 0 (zero) to not have any fade effect on that end.
@@ -1131,7 +1131,7 @@ out for the last one quarter second it is displayed.
 在字幕显示时间的头1.2秒淡入，在尾部0.25秒淡出。
 {{</example-box>}}
 
-{{<tag-def-box title="渐变（复杂）" id="\fade">}}\\fade(<i>\<a1</i>>,<i>\<a2</i>>,<i>\<a3</i>>,<i>\<t1</i>>,<i>\<t2</i>>,<i>\<t3</i>>,<i>\<t4</i>>){{</tag-def-box>}}
+{{%tag-def-box title="渐变（复杂）"%}}\\fade(<i>\<a1</i>>,<i>\<a2</i>>,<i>\<a3</i>>,<i>\<t1</i>>,<i>\<t2</i>>,<i>\<t3</i>>,<i>\<t4</i>>){{%/tag-def-box%}}
 Perform a five-part fade using three alpha values _a1_, _a2_ and _a3_ and four
 times _t1_, _t2_, _t3_ and _t4_.
 
@@ -1170,12 +1170,12 @@ Second fade starts 1500 milliseconds later, and lasts 200 milliseconds.
 从完全透明，渐变到几乎完全不透明，然后渐变到几乎完全透明。第一个渐变开始于字幕开始时，持续500毫秒。第二个渐变开始于1500毫秒后，持续200毫秒。
 {{</example-box>}}
 
-{{<tag-def-box title="动画效果" id="\t">}}
+{{%tag-def-box title="动画效果"%}}
 \\t(<i>\<style modifiers></i>)
 \\t(<i>\<accel></i>,<i>\<style modifiers></i>)
 \\t(<i>\<t1</i>>,<i>\<t2</i>>,<i>\<style modifiers></i>)
 \\t(<i>\<t1</i>>,<i>\<t2</i>>,<i>\<accel></i>,<i>\<style modifiers></i>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 
 Perform a gradual, animated transformation from one style to another. The
 _style modifiers_ are other override tags as specified in this reference. Only
@@ -1298,10 +1298,10 @@ Text starts at zero size, i.e. invisible, then grows to 100% size in both X and 
 字符开始尺寸是0，然后在 X 和 Y方向同时变化到正常大小。
 {{</example-box>}}
 
-{{<tag-def-box title="遮罩（方形" id="\clip">}}
+{{%tag-def-box title="遮罩（方形"%}}
 \\clip(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>)
 \\iclip(<i>\<x1</i>>,<i>\<y1</i>>,<i>\<x2</i>>,<i>\<y2</i>>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Define a rectangle to clip the line, only the part of the line that is inside
 the rectangle is visible. The `\iclip` tag has the opposite effect, it defines
 a rectangle where the line is not shown.
@@ -1353,7 +1353,7 @@ Example of `\clip(0,0,704,245)` on a 704x480 video:
 \\clip(<i>\<scale></i>,<i>\<drawing commands></i>)
 \\iclip(<i>\<drawing commands></i>)
 \\iclip(<i>\<scale></i>,<i>\<drawing commands></i>)
-{{</tag-def-box>}}
+{{%/tag-def-box%}}
 Use the shape defined by a vector drawing to selectively display (`\clip`) or
 hide (`\iclip`) parts of the line.
 

--- a/layouts/shortcodes/tag-def-box.html
+++ b/layouts/shortcodes/tag-def-box.html
@@ -1,2 +1,3 @@
-<h3 id="{{ .Get "id" | safeHTML }}">{{ .Get "title" | safeHTML }}</h3>
+### {{.Get "title"}}
+
 <pre><code class="language-plaintext">{{ markdownify .Inner | safeHTML }}</code></pre>


### PR DESCRIPTION
Hugo wasn't including header elements generated with the `tag-def-box` into the table of contents. This is a [known problem](https://www.jakewiesler.com/blog/anchored-headings-in-hugo) with Hugo. I am using jakewiesler's work-around where you use Markdown headers in the short code and call it with `{{% short-code %}}` instead of `{{< short-code>}}`. This also makes the generated headers consistent with the rest of the headers in the document. 

This does lose the `id`s which were the .ass code rather than plain-language description. 